### PR TITLE
Add as.list()

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -3,6 +3,7 @@
 S3method(as.coefficients_textmodel,data.frame)
 S3method(as.coefficients_textmodel,matrix)
 S3method(as.coefficients_textmodel,numeric)
+S3method(as.list,textmodel_newsmap)
 S3method(as.statistics_textmodel,data.frame)
 S3method(as.statistics_textmodel,matrix)
 S3method(coef,textmodel_newsmap)

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,3 +1,10 @@
+#' @keywords internal
+#' @export
+#' @method as.list textmodel_newsmap
+#' @param ... passed to [coef.textmodel_newsmap]
+as.list.textmodel_newsmap <- function(x, ...) {
+    lapply(coef(x, ...), names)
+}
 
 #' @export
 #' @method print textmodel_newsmap

--- a/tests/testthat/test-textmodel.R
+++ b/tests/testthat/test-textmodel.R
@@ -191,7 +191,7 @@ test_that("afe() is working", {
     expect_error(afe(list(), dfmt_label))
 })
 
-test_that("coef() is working", {
+test_that("coef() and dictionary() are working", {
 
     dfmt <- dfm_trim(dfmt_test, min_termfreq = 100)
     dfmt_dict <- dfm_trim(dfmt_dict_test, min_termfreq = 2)
@@ -213,4 +213,13 @@ test_that("coef() is working", {
     expect_error(coef(map, select = character()),
                  "The length of select must be between 1 and 16")
 
+    lis1 <- as.list(map)
+    expect_equal(length(lis1), 16)
+    expect_true(all(sapply(lis1, is.character)))
+    expect_true(all(lengths(as.list(lis1)) == 10))
+
+    lis2 <- as.list(map, n = 20, c("ru", "fr"))
+    expect_equal(names(lis2), c("ru", "fr"))
+    expect_true(all(sapply(lis2, is.character)))
+    expect_true(all(lengths(lis2) == 20))
 })


### PR DESCRIPTION
Add `as.list()` instead of `as.dictionary()` because its generic function does not have `...`.