### PR TITLE
Required changes because of data_corpus_inaugural fix

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -7,3 +7,4 @@
 ^dev/
 ^testthat/
 cran-comments\.md
+^codecov\.yml$

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -15,7 +15,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-r@v2
         with:
@@ -44,7 +44,7 @@ jobs:
 
       - name: Upload test results
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-test-failures
           path: ${{ runner.temp }}/package

--- a/README.Rmd
+++ b/README.Rmd
@@ -22,6 +22,7 @@ Downloads](https://cranlogs.r-pkg.org/badges/grand-total/newsmap?color=orange)](
 [![R build
 status](https://github.com/koheiw/newsmap/workflows/R-CMD-check/badge.svg)](https://github.com/koheiw/newsmap/actions)
 [![codecov](https://codecov.io/gh/koheiw/newsmap/branch/master/graph/badge.svg)](https://codecov.io/gh/koheiw/newsmap)
+[![Codecov test coverage](https://codecov.io/gh/koheiw/newsmap/graph/badge.svg)](https://app.codecov.io/gh/koheiw/newsmap)
 <!-- badges: end -->
 
 Semi-supervised Bayesian model for geographical document classification. Newsmap automatically constructs a large geographical dictionary from a corpus to accurate classify documents. Currently, the **newsmap** package contains seed dictionaries in multiple languages that include *English*, *German*, *French*, *Spanish*, *Portuguese*, *Russian*, *Italian*, *Arabic*, *Turkish*, *Hebrew*, *Japanese*, *Chinese*.

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,14 @@
+comment: false
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true
+    patch:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true

--- a/tests/testthat/test-textmodel.R
+++ b/tests/testthat/test-textmodel.R
@@ -235,11 +235,11 @@ test_that("coef() and dictionary() are working", {
     expect_error(coef(map, select = "xx"),
                  "Selected class must be in the model")
     expect_error(coef(map, select = character()),
-                 "The length of select must be between 1 and 16")
+                 "The length of select must be between 1 and 1\\d")
 
     # TODO: remove as.list()
     lis1 <- as.list(map)
-    expect_equal(length(lis1), 16)
+    expect_equal(length(lis1), 17)
     expect_true(all(sapply(lis1, is.character)))
     expect_true(all(lengths(as.list(lis1)) == 10))
 

--- a/tests/testthat/test-textmodel.R
+++ b/tests/testthat/test-textmodel.R
@@ -1,6 +1,6 @@
 require(quanteda)
 
-toks_test <- tokens(data_corpus_inaugural, remove_punct = TRUE)
+toks_test <- tokens(data_corpus_inaugural[1:59], remove_punct = TRUE)
 dfmt_test <- dfm(toks_test) %>%
     dfm_remove(stopwords("en"))
 toks_dict_test <- tokens_lookup(toks_test, data_dictionary_newsmap_en, level = 3)

--- a/tests/testthat/test-textmodel.R
+++ b/tests/testthat/test-textmodel.R
@@ -1,6 +1,6 @@
 require(quanteda)
 
-toks_test <- tokens(data_corpus_inaugural, remove_punct = TRUE)
+toks_test <- tokens(data_corpus_inaugural[1:59], remove_punct = TRUE)
 dfmt_test <- dfm(toks_test) %>%
     dfm_remove(stopwords("en"))
 toks_dict_test <- tokens_lookup(toks_test, data_dictionary_newsmap_en, level = 3)
@@ -235,11 +235,11 @@ test_that("coef() and dictionary() are working", {
     expect_error(coef(map, select = "xx"),
                  "Selected class must be in the model")
     expect_error(coef(map, select = character()),
-                 "The length of select must be between 1 and 1\\d")
+                 "The length of select must be between 1 and 16")
 
     # TODO: remove as.list()
     lis1 <- as.list(map)
-    expect_equal(length(lis1), 17)
+    expect_equal(length(lis1), 16)
     expect_true(all(sapply(lis1, is.character)))
     expect_true(all(lengths(as.list(lis1)) == 10))
 


### PR DESCRIPTION
From quanteda 4.3.1

The last speech in data_corpus_inaugural from quanteda 4.3.0 was wrong; after fixing this, it changed the length of some of your text objects (from 16 to 17). I fixed this by limiting the data_corpus_inaugural to the first 59 documents.

I also updated the actions for the code coverage, since yours were still using a deprecated version.